### PR TITLE
Add CSS Variable for Border Radius

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,6 +105,7 @@ body {
   --sb-track-color: ${this.trackColor};
   --sb-thumb-color: ${this.thumbColor};
   --sb-size: ${this.width}px;
+  --sb-border-radius: ${this.scrollbarBorderRadius}px;
 }
 
 body::-webkit-scrollbar {
@@ -113,12 +114,12 @@ body::-webkit-scrollbar {
 
 body::-webkit-scrollbar-track {
   background: var(--sb-track-color);
-  border-radius: ${this.scrollbarBorderRadius}px;
+  border-radius: var(--sb-border-radius);
 }
 
 body::-webkit-scrollbar-thumb {
   background: var(--sb-thumb-color);
-  border-radius: ${this.scrollbarBorderRadius}px;
+  border-radius: var(--sb-border-radius);
   ${
     this.scrollbarThumbBorderWidth > 0
       ? 'border: ' +
@@ -296,6 +297,7 @@ body {
   --sb-track-color: {{ trackColor }};
   --sb-thumb-color: {{ thumbColor }};
   --sb-size: {{ width }}px;
+  --sb-border-radius: {{ scrollbarBorderRadius }}px;
 }
 
 body::-webkit-scrollbar {
@@ -304,12 +306,12 @@ body::-webkit-scrollbar {
 
 body::-webkit-scrollbar-track {
   background: var(--sb-track-color);
-  border-radius: {{ scrollbarBorderRadius }}px;
+  border-radius: var(--sb-border-radius);
 }
 
 body::-webkit-scrollbar-thumb {
   background: var(--sb-thumb-color);
-  border-radius: {{ scrollbarBorderRadius }}px;
+  border-radius: var(--sb-border-radius);
 {{
             scrollbarThumbBorderWidth > 0
               ? '  border: ' +


### PR DESCRIPTION
In the current website, border radius is referenced twice directly as a number.

![original website, border radius as magic number](https://github.com/henripar/scrollbar/assets/33791257/66e1f53b-a960-4d87-a0a0-1b7e5e5b0719)

This PR makes border radius a CSS variable (as `--sb-border-radius`), similar to all the other properties (`--sb-track-color`, `--sb-thumb-color`, and `--sb-size`).

![new website after PR, border radius as CSS variable](https://github.com/henripar/scrollbar/assets/33791257/02136c35-282f-4d73-92d1-7e1ddda9d547)
